### PR TITLE
fixed to work with Redmine 4.2.4.stable.21493

### DIFF
--- a/app/views/layouts/view_attachment_inline.html.erb
+++ b/app/views/layouts/view_attachment_inline.html.erb
@@ -9,7 +9,7 @@
 <meta name="keywords" content="issue,bug,tracker" />
 <%= csrf_meta_tag %>
 <%= favicon %>
-<%= stylesheet_link_tag 'jquery/jquery-ui-1.11.0', 'application', 'responsive', :media => 'all' %>
+<%= stylesheet_link_tag 'jquery/jquery-ui-1.12.1', 'application', 'responsive', :media => 'all' %>
 <%= stylesheet_link_tag 'rtl', :media => 'all' if l(:direction) == 'rtl' %>
 <%= javascript_heads %>
 <%= heads_for_theme %>


### PR DESCRIPTION
This is probably not the best solution, it should somehow bind to whichever jquery UI css is used by Redmine, automatically or pack it's own jquery UI css files...

